### PR TITLE
Used available format for sharp converter

### DIFF
--- a/src/services/fcs.service.ts
+++ b/src/services/fcs.service.ts
@@ -21,7 +21,7 @@ export class FCSService {
   ): Promise<String> {
     const bucket = firebaseAdmin.storage().bucket();
     const tempDir = os.tmpdir();
-    const baseName = path.basename(filePath);
+    const baseName = path.parse(filePath).name;
     let format = 'jpg';
     let mutations = [
       {
@@ -65,14 +65,14 @@ export class FCSService {
       if (mutation.type === 'origin') {
         if (type === UploadType.IMAGE) {
           await sharp(filePath)
-            .toFormat(sharp.format.jpg)
+            .toFormat('jpg')
             .toFile(formattedFilePath);
         } else {
           await new Promise((resolve, reject) => {
             ffmpeg(filePath)
               .videoCodec('libx264')
               .audioCodec('libmp3lame')
-              .format(format)
+              .format('mp4')
               .on('error', err => {
                 reject(err);
               })
@@ -86,7 +86,7 @@ export class FCSService {
         if (type === UploadType.IMAGE) {
           await sharp(filePath)
             .resize({width: mutation.width})
-            .toFormat(sharp.format.jpg)
+            .toFormat('jpg')
             .toFile(formattedFilePath);
         }
       }


### PR DESCRIPTION
# Title

- [ ] JIRA Issue ID (preferably only ONE parent issue, put subtask IDs in the Description)
- [ ] Multiple JIRA Issue IDs? Are you sure your PR isn't too big? Can you rebase your commits to new branches so there's only 1 issue ID?
- [ ] Is your title relatable to the JIRA issue?
- [ ] Title <= 100 characters

# Description

Please include a summary of the change in dot point form. Please also include relevant motivation for decisions you made and if there are any TODO items you could not complete. List any dependencies that you added (e.g. package.json).

For example:

- Filename.js: Added comment button to CommentComponent
  - I only enabled the button if the user has logged in (motivation)
  - I couldn't figure out a way to centre the button with flexbox (TODO)
- Filename2.js: bla bla bla
  - nocus dorem iptus locum
- package.json:
  - Added sharp version 2.1.0
    - Need this to compress images (motivation)
    - Tried compress-js but it's deprecated (more motivation)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Builds and runs on Windows
- [ ] Builds and runs on MacOS
- [ ] Builds and runs on Linux
- [ ] Builds and runs on Docker (Linux)
- [ ] Unit tests?
- [ ] Integration tests?
- [ ] End-to-end (E2E) tests?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Have you added yourself as the Assignee?
- [ ] Have you added 1 or more leads as the Reviewer?
- [ ] Have you chosen 1-2 of the following labels?
  - Feature
  - Bug
  - Refactor
  - Test
  - Documentation
