### PR TITLE
fix: user counter when imported post

### DIFF
--- a/src/interceptors/create.interceptor.ts
+++ b/src/interceptors/create.interceptor.ts
@@ -729,6 +729,8 @@ export class CreateInterceptor implements Provider<Interceptor> {
 
         Promise.allSettled([
           this.tagService.createTags(result.tags),
+          this.metricService.userMetric(user?.id ?? ''),
+          this.metricService.countServerMetric(),
           this.activityLogService.createLog(
             ActivityLogType.IMPORTPOST,
             result.createdBy,


### PR DESCRIPTION
## Describe your changes
- added user metrics and server metrics when the post is imported

## Issue ticket number / link
[MYR-2327: Post counter in profile doesn't count imported post](https://blocksphere2020.atlassian.net/browse/MYR-2327)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
